### PR TITLE
Use self.hass.config.path() to build the path for the `solcast.json' file

### DIFF
--- a/custom_components/solcast_solar/__init__.py
+++ b/custom_components/solcast_solar/__init__.py
@@ -28,7 +28,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             SOLCAST_URL
         )
 
-        solcast = SolcastApi(aiohttp_client.async_get_clientsession(hass), options)
+        solcast = SolcastApi(hass, aiohttp_client.async_get_clientsession(hass), options)
         await solcast.sites_data()
         await solcast.load_saved_data()
         

--- a/custom_components/solcast_solar/solcastapi.py
+++ b/custom_components/solcast_solar/solcastapi.py
@@ -11,6 +11,7 @@ from operator import itemgetter
 from os.path import exists as file_exists
 from typing import Any, cast
 
+from homeassistant.core import HomeAssistant
 from aiohttp import ClientConnectionError, ClientSession
 import asyncio
 import async_timeout
@@ -51,16 +52,18 @@ class SolcastApi:
 
     def __init__(
         self,
+        hass: HomeAssistant,
         aiohttp_session: ClientSession,
         options: ConnectionOptions,
     ):
         """Device init."""
+        self.hass = hass
         self.aiohttp_session = aiohttp_session
         self.options = options
         self._sites = []
         self._data = dict({'forecasts':[], 'energy': {}, 'api_used':0, 'last_updated': dt.now(timezone.utc).replace(year=2000,month=1,day=1).isoformat()})
         self._api_used = 0
-        self._filename = f'solcast.json'
+        self._filename = self.hass.config.path('solcast.json')
 
     async def sites_data(self):
         """Request data via the Solcast API."""


### PR DESCRIPTION
HASS was trying to create the `solcast.json` file at `/` on my Home Assistant Core installation. I did minimal changes to have the path built from the `hass.config.path()` method. I do not have any way to test the other installation methods, but the `hass.config.path()` method is used by several other HASS addons I have installed.