### PR TITLE
Forecast attribute fixes

### DIFF
--- a/custom_components/solcast_solar/solcastapi.py
+++ b/custom_components/solcast_solar/solcastapi.py
@@ -17,7 +17,7 @@ import async_timeout
 from aiohttp.client_reqrep import ClientResponse
 from isodate import parse_datetime
 
-_JSON_VERSION = 1
+_JSON_VERSION = 2
 _LOGGER = logging.getLogger(__name__)
 
 class DateTimeEncoder(json.JSONEncoder):
@@ -33,7 +33,7 @@ class JSONDecoder(json.JSONDecoder):
     def object_hook(self, obj):
         ret = {}
         for key, value in obj.items():
-            if key in {'period_end'}:
+            if key in {'period_start'}:
                 ret[key] = dt.fromisoformat(value) 
             else:
                 ret[key] = value
@@ -223,10 +223,10 @@ class SolcastApi:
             da = dt.now().replace(minute=0, second=0, microsecond=0)
             h = da.hour
             da = da.date()
-            g = [d for d in self._data["forecasts"] if d['period_end'].date() == da]
+            g = [d for d in self._data["forecasts"] if d['period_start'].date() == da]
             tot = 0
             for p in g:
-                if p["period_end"].hour >= h:
+                if p["period_start"].hour >= h:
                     tot += p["pv_estimate"]
             
             return round(tot,2)
@@ -237,7 +237,7 @@ class SolcastApi:
         """Return Solcast Forecasts data for today"""
         try:
             da = dt.now().replace(minute=0, second=0, microsecond=0).date()
-            g = [d for d in self._data["forecasts"] if d['period_end'].date() == da]
+            g = [d for d in self._data["forecasts"] if d['period_start'].date() == da]
             return {"forecast": g}
         except Exception:
             return {}
@@ -246,7 +246,7 @@ class SolcastApi:
         """Return Solcast Forecasts data for tomorrow"""
         try:
             da = dt.now().replace(minute=0, second=0, microsecond=0).date() + timedelta(days=1)
-            g = [d for d in self._data["forecasts"] if d['period_end'].date() == da]
+            g = [d for d in self._data["forecasts"] if d['period_start'].date() == da]
             return {"forecast": g}
         except Exception:
             return {}
@@ -254,7 +254,7 @@ class SolcastApi:
     def get_forecast_this_hour(self) -> int:
         try:
             da = dt.now().replace(minute=0, second=0, microsecond=0).astimezone()
-            g = [d for d in self._data["forecasts"] if d['period_end'] == da]   
+            g = [d for d in self._data["forecasts"] if d['period_start'] == da]   
             return int(g[0]['pv_estimate'] * 1000)
         except Exception:
             return 0
@@ -262,7 +262,7 @@ class SolcastApi:
     def get_forecast_next_hour(self) -> int:
         try:
             da = dt.now().replace(minute=0, second=0, microsecond=0).astimezone() + timedelta(hours=1)
-            g = [d for d in self._data["forecasts"] if d['period_end'] == da]   
+            g = [d for d in self._data["forecasts"] if d['period_start'] == da]   
             return int(g[0]['pv_estimate'] * 1000)
         except Exception:
             return 0
@@ -271,7 +271,7 @@ class SolcastApi:
         """Return total kwh total for rooftop site today"""
         try:
             da = dt.now().replace(minute=0, second=0, microsecond=0).date()
-            g = [d for d in self._data["forecasts"] if d['period_end'].date() == da]
+            g = [d for d in self._data["forecasts"] if d['period_start'].date() == da]
             return round(sum(z['pv_estimate'] for z in g if z),2)
         except Exception:
             return 0
@@ -280,7 +280,7 @@ class SolcastApi:
         """Return hour of max kw for rooftop site today"""
         try:
             da = dt.now().replace(minute=0, second=0, microsecond=0).date()
-            g = [d for d in self._data["forecasts"] if d['period_end'].date() == da]
+            g = [d for d in self._data["forecasts"] if d['period_start'].date() == da]
             m = max(z['pv_estimate'] for z in g if z) 
             return int(m * 1000)
         except Exception:
@@ -290,12 +290,12 @@ class SolcastApi:
         """Return hour of max kw for rooftop site today"""
         try:
             da = dt.now().replace(minute=0, second=0, microsecond=0).date()
-            g = [d for d in self._data["forecasts"] if d['period_end'].date() == da]
+            g = [d for d in self._data["forecasts"] if d['period_start'].date() == da]
             m = max(z['pv_estimate'] for z in g if z) 
 
             for v in g:
                 if v['pv_estimate'] == m:
-                    return v['period_end']
+                    return v['period_start']
                     #return p.isoformat()
             return None
         except Exception:
@@ -305,7 +305,7 @@ class SolcastApi:
         """Return total kwh total for rooftop site tomorrow"""
         try:
             da = dt.now().replace(minute=0, second=0, microsecond=0).date() + timedelta(days=1)
-            g = [d for d in self._data["forecasts"] if d['period_end'].date() == da]
+            g = [d for d in self._data["forecasts"] if d['period_start'].date() == da]
             return round(sum(z['pv_estimate'] for z in g if z),2)
         except Exception:
             return 0
@@ -314,7 +314,7 @@ class SolcastApi:
         """Return hour of max kw for rooftop site tomorrow"""
         try:
             da = dt.now().replace(minute=0, second=0, microsecond=0).date() + timedelta(days=1)
-            g = [d for d in self._data["forecasts"] if d['period_end'].date() == da]
+            g = [d for d in self._data["forecasts"] if d['period_start'].date() == da]
             m = max(z['pv_estimate'] for z in g if z) 
             return int(m * 1000)
         except Exception:
@@ -324,12 +324,12 @@ class SolcastApi:
         """Return hour of max kw for rooftop site tomorrow"""
         try:
             da = dt.now().replace(minute=0, second=0, microsecond=0).date() + timedelta(days=1)
-            g = [d for d in self._data["forecasts"] if d['period_end'].date() == da]
+            g = [d for d in self._data["forecasts"] if d['period_start'].date() == da]
             m = max(z['pv_estimate'] for z in g if z) 
 
             for v in g:
                 if v['pv_estimate'] == m:
-                    return v['period_end']
+                    return v['period_start']
                     #  return p.isoformat() ??
             return None
         except Exception:
@@ -377,9 +377,9 @@ class SolcastApi:
                         if z.date() == today:
                             # The pv_estimate from solcast is an average power figure. This code assumes
                             # each slot is 30 minutes long so *0.5 to convert to an energy figure in kwh 
-                            _data.append({"period_end": z,"pv_estimate": x["pv_estimate"]*0.5})
+                            _data.append({"period_start": z,"pv_estimate": x["pv_estimate"]*0.5})
 
-                    _data = sorted(_data, key=itemgetter("period_end"))
+                    _data = sorted(_data, key=itemgetter("period_start"))
                     #_s.update({site['resource_id']:{'estimated_actuals': _data}})
 
                 af = await self.fetch_data("forecasts", 168, site=site['resource_id'], apikey=site['apikey'])
@@ -391,62 +391,62 @@ class SolcastApi:
                 for x in af['forecasts']:
                     z = parse_datetime(x['period_end']).astimezone() - timedelta(minutes=30)
                     if z.date() < lastday:
-                        _data2.append({"period_end": z,"pv_estimate": x["pv_estimate"]*0.5})
+                        _data2.append({"period_start": z,"pv_estimate": x["pv_estimate"]*0.5})
 
-                # _data2 = sorted(_data2, key=itemgetter("period_end"))
+                # _data2 = sorted(_data2, key=itemgetter("period_start"))
                 # _s.update({site['resource_id']:{'forecasts': _data2}})
                 
                 if dopast:
                     # There can be some overlap between the estimated actuals and the forecast, so only add
                     # a forcast sample if we don't already have that data point.
-                    actualsTimestamps = list(map(lambda x: x["period_end"], _data))
-                    _data.extend(filter(lambda x: x["period_end"] not in actualsTimestamps, _data2))
+                    actualsTimestamps = list(map(lambda x: x["period_start"], _data))
+                    _data.extend(filter(lambda x: x["period_start"] not in actualsTimestamps, _data2))
                 else:
                     #_LOGGER.debug("not doing past data so fill ion the blanks")
                     _data = _olddata['siteinfo'][site['resource_id']]['forecasts']
                     for item in _data2:
-                        found_data = [d for d in _data if d['period_end'] == item['period_end']]
+                        found_data = [d for d in _data if d['period_start'] == item['period_start']]
                         if len(found_data) > 0:
                             #_LOGGER.warn(f"found this to update {found_data[0]}")
-                            found_data[0].update({"period_end": item['period_end'],"pv_estimate": item['pv_estimate']})
+                            found_data[0].update({"period_start": item['period_start'],"pv_estimate": item['pv_estimate']})
                         else:
                             #_LOGGER.warn(f"did not found update so adding to list")
-                            _data.append({"period_end": item['period_end'],"pv_estimate": item['pv_estimate']})
+                            _data.append({"period_start": item['period_start'],"pv_estimate": item['pv_estimate']})
 
-                _data = sorted(_data, key=itemgetter("period_end"))
+                _data = sorted(_data, key=itemgetter("period_start"))
                 _s.update({site['resource_id']:{'forecasts': _data}})
 
                 # _LOGGER.debug("OK up to here now.. should be midnight today")
                 # _LOGGER.debug(_data[0])
 
                 for n in range(len(_data)-1):
-                    _sec = _data[n+1]["period_end"] - _data[n]["period_end"]
+                    _sec = _data[n+1]["period_start"] - _data[n]["period_start"]
                     if _sec.seconds > 1800:  #more than 30min then we are missing data
-                        #_LOGGER.warn(f"Solcast missing forecast interval item from {_data[n]['period_end']} to {_data[n+1]['period_end']}")
-                        findme = _data[n]["period_end"] + timedelta(minutes=30)
+                        #_LOGGER.warn(f"Solcast missing forecast interval item from {_data[n]['period_start']} to {_data[n+1]['period_start']}")
+                        findme = _data[n]["period_start"] + timedelta(minutes=30)
                         if site['resource_id'] in _olddata:
                             if 'forecasts' in _olddata[site['resource_id']] :
                                 
-                                inset_data = [d for d in _olddata[site['resource_id']]["forecasts"] if d['period_end'] == findme.isoformat()]
+                                inset_data = [d for d in _olddata[site['resource_id']]["forecasts"] if d['period_start'] == findme.isoformat()]
                                 if len(inset_data) > 0:
-                                    z = parse_datetime(inset_data[0]['period_end']).astimezone() 
+                                    z = parse_datetime(inset_data[0]['period_start']).astimezone() 
                                     #_LOGGER.debug("adding missing solcast item {inset_data}")
-                                    _data.append({"period_end": z,"pv_estimate": inset_data[0]["pv_estimate"]})
+                                    _data.append({"period_start": z,"pv_estimate": inset_data[0]["pv_estimate"]})
                                 else:
                                     #_LOGGER.debug("IS old data to fill in the missing data but didnt find any match so adding empty item as 0 value")
-                                    _data.append({"period_end": findme.astimezone(),"pv_estimate": 0})
+                                    _data.append({"period_start": findme.astimezone(),"pv_estimate": 0})
                         else:
                             #_LOGGER.debug("No old data to fill in the missing data so adding empty item as 0 value")
-                            _data.append({"period_end": findme.astimezone(),"pv_estimate": 0})
+                            _data.append({"period_start": findme.astimezone(),"pv_estimate": 0})
 
-                _data = sorted(_data, key=itemgetter("period_end"))
+                _data = sorted(_data, key=itemgetter("period_start"))
 
                 if not (len(_data) % 2) == 0:
                     del _data[-1]
 
                 tally_today = 0
                 for x in _data:
-                    if x['period_end'].date() == today:
+                    if x['period_start'].date() == today:
                         tally_today += x["pv_estimate"]
 
                 _s[site['resource_id']]['tally'] = round(tally_today,2)
@@ -459,15 +459,15 @@ class SolcastApi:
                 for x in it:
                     a = x
                     b = next(it)
-                    # if not a['period_end'].hour == b['period_end'].hour:
+                    # if not a['period_start'].hour == b['period_start'].hour:
                     #     #_LOGGER.error(f"not same hour for {a} and {b}")
                     #     _LOGGER.warn(f"solcast - api error.. dam it! still missing data from solcast api between hours {a} and {b}")
-                    if a['period_end'].minute == 0:
-                        _d.append({"period_end": a['period_end'],"pv_estimate": (a["pv_estimate"] + b["pv_estimate"])})
+                    if a['period_start'].minute == 0:
+                        _d.append({"period_start": a['period_start'],"pv_estimate": (a["pv_estimate"] + b["pv_estimate"])})
                     else:
                         #_LOGGER.warn("hmm this should not have data at the 30min mark.. should be on the hour values")
-                        _t = a['period_end'].replace(minute=0)
-                        _d.append({"period_end": _t,"pv_estimate": (a["pv_estimate"] + b["pv_estimate"])})
+                        _t = a['period_start'].replace(minute=0)
+                        _d.append({"period_start": _t,"pv_estimate": (a["pv_estimate"] + b["pv_estimate"])})
 
 
                 if len(self._data) == 0:
@@ -481,7 +481,7 @@ class SolcastApi:
                 self._data = _olddata
                 self._data['api_used'] = self._api_used
             else:
-                #self._data = sorted(self._data, key=itemgetter("period_end"))
+                #self._data = sorted(self._data, key=itemgetter("period_start"))
                 self._data = dict({"forecasts": self._data})
 
                 self._data["energy"] = {"wh_hours": self.makeenergydict()}
@@ -565,7 +565,7 @@ class SolcastApi:
             lastv = -1
             lastk = -1
             for v in self._data["forecasts"]:
-                d = v['period_end'].isoformat()
+                d = v['period_start'].isoformat()
                 if v['pv_estimate'] == 0.0:
                     if lastv > 0.0:
                         wh_hours[d] = v['pv_estimate'] * 1000

--- a/custom_components/solcast_solar/test.py
+++ b/custom_components/solcast_solar/test.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python3
+
+from solcastapi import ConnectionOptions, SolcastApi
+from aiohttp import ClientConnectionError, ClientSession
+import asyncio
+import logging
+
+
+#logging.basicConfig(level=logging.DEBUG)
+_LOGGER = logging.getLogger(__name__)
+
+
+async def test():
+    try:
+        
+        options = ConnectionOptions(
+            "wx1VCTwmhW5Foh4nj6jeKzOtW9aVg9Hk",
+            "https://api.solcast.com.au",
+            'solcast.json'
+        )
+        
+        async with ClientSession() as session:
+            solcast = SolcastApi(session, options, apiCacheEnabled=True)
+            await solcast.sites_data()
+            await solcast.load_saved_data()
+            print("Total today " + str(solcast.get_total_kwh_forecast_today()))
+            print("Peak today " + str(solcast.get_peak_w_today()))
+            print("Peak time today " + str(solcast.get_peak_w_time_today()))
+    except Exception as err:
+        _LOGGER.error("async_setup_entry: %s",traceback.format_exc())
+        return False
+
+
+asyncio.run(test())


### PR DESCRIPTION
The forecast attributes had a few bugs that this patch fixes:

- The cross over between estimated actuals and forecasts could result in duplicate samples
- The timestamps were labeled as "period_end" when they were actually for the start of the period
- The attributes only contained data in 1 hour chunks. Since UK electricity prices change every 30 minutes exposing the resolution available is useful. 