### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ trigger:
       {% set interval_hours = hours_difference / api_request_limit %}
       {% set ns = namespace(match = false) %}
       {% for i in range(api_request_limit) %}
-        {% set start_time = nr + (i - 1 ) * interval_hours %}
+        {% set start_time = nr + (i * interval_hours) %}
         {% if ((start_time - timedelta(seconds=30)) <= now()) and (now() <= (start_time + timedelta(seconds=30))) %}
           {% set ns.match = true %}
         {% endif %}


### PR DESCRIPTION
Reverting the change to (n - 1) in the FOR loop of the example automation. The change was incorrect.
For example: `for i in range (10)` actually loops through 0-9 so the `n-1` is not needed.
Sorry for the mistake.