### PR TITLE
Fix missing `description` value in example automation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ To make the most of the available API calls, you can call the API in an interval
 
 ```yaml
 alias: Solcast update
-description:
+description: ""
 trigger:
   - platform: template
     value_template: >-


### PR DESCRIPTION
Make the example valid to copy paste straight into an automation