### PR TITLE
Update README to include random delays in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ condition:
    before: sunset
    after: sunrise
 action:
+ - delay:
+     seconds: "{{ range(30, 360)|random|int }}"
  - service: solcast_solar.update_forecasts
    data: {}
 mode: single
@@ -131,6 +133,8 @@ trigger:
     at: "16:00:00"
 condition: []
 action:
+  - delay:
+      seconds: "{{ range(30, 360)|random|int }}"
   - service: solcast_solar.update_forecasts
     data: {}
 mode: single
@@ -164,6 +168,8 @@ condition:
     before: sunset
     after: sunrise
 action:
+  - delay:
+      seconds: "{{ range(30, 360)|random|int }}"
   - service: solcast_solar.update_forecasts
     data: {}
 mode: single


### PR DESCRIPTION
To help reduce the impact on the Solcast backend, Solcast have asked that users set their automation for polling with a random min and sec timing.. if you are polling at say 10:00 set it to 10:04:10 for instance so that everyone is not polling the services at the same time

This PR will add a random delay on Solcast updates between 30 and 360 seconds in the examples.