### PR TITLE
Code optimizations to "buildforcastdata" in solcastapi.py.

### DIFF
--- a/custom_components/solcast_solar/solcastapi.py
+++ b/custom_components/solcast_solar/solcastapi.py
@@ -748,37 +748,36 @@ class SolcastApi:
             yesterday = dt.now(self._tz).date() + timedelta(days=-730)
             lastday = dt.now(self._tz).date() + timedelta(days=7)
             
-            _forecasts = []
-        
-            for s in self._data['siteinfo']:
+            _forecasts = {}
+
+            for s, siteinfo in self._data['siteinfo'].items():
                 tally = 0
-                for x in self._data['siteinfo'][s]['forecasts']:   
+                for x in siteinfo['forecasts']:   
                     #loop each rooftop site and its forecasts
                     z = x["period_start"]
                     zz = z.astimezone(self._tz) #- timedelta(minutes=30)
 
                     #v4.0.8 added code to dampen the forecast data.. (* self._damp[h])
                     
-                    if zz.date() < lastday and zz.date() > yesterday:
+                    if yesterday < zz.date() < lastday:
                         h = f"{zz.hour}"
                         if zz.date() == today:
                             tally += min(x[self._use_data_field] * 0.5 * self._damp[h], self._hardlimit)
                         
-                        itm = next((item for item in _forecasts if item["period_start"] == z), None)
+                        itm = _forecasts.get(z)
                         if itm:
                             itm["pv_estimate"] = min(round(itm["pv_estimate"] + (x["pv_estimate"] * self._damp[h]),4), self._hardlimit)
                             itm["pv_estimate10"] = min(round(itm["pv_estimate10"] + (x["pv_estimate10"] * self._damp[h]),4), self._hardlimit)
                             itm["pv_estimate90"] = min(round(itm["pv_estimate90"] + (x["pv_estimate90"] * self._damp[h]),4), self._hardlimit)
                         else:    
-                            _forecasts.append({"period_start": z,"pv_estimate": min(round((x["pv_estimate"]* self._damp[h]),4), self._hardlimit),
-                                                                "pv_estimate10": min(round((x["pv_estimate10"]* self._damp[h]),4), self._hardlimit),
-                                                                "pv_estimate90": min(round((x["pv_estimate90"]* self._damp[h]),4), self._hardlimit)})
-                        
-                self._data['siteinfo'][s]['tally'] = round(tally, 4)
-                        
-            _forecasts = sorted(_forecasts, key=itemgetter("period_start"))     
-            
-            self._data_forecasts = _forecasts 
+                            _forecasts[z] = {"period_start": z,"pv_estimate": min(round((x["pv_estimate"]* self._damp[h]),4), self._hardlimit),
+                                            "pv_estimate10": min(round((x["pv_estimate10"]* self._damp[h]),4), self._hardlimit),
+                                            "pv_estimate90": min(round((x["pv_estimate90"]* self._damp[h]),4), self._hardlimit)}
+                
+                siteinfo['tally'] = round(tally, 4)
+
+            self._data_forecasts = list(_forecasts.values())
+            self._data_forecasts.sort(key=itemgetter("period_start"))
 
             await self.checkDataRecords()
                     


### PR DESCRIPTION
I noticed I had some weird issues in HA around the time that the integration was updating the forecast.
These were things like:
- Zigbee timeouts / errors
- Modbus timeouts

Once I enabled debug logging for the Solcast integration I noticed there was a big delay in the `buildforcastdata` method in `solcastapi.py`. 

Without checking the code myself I asked Github Copilot if he could optimize the code and he came up with some easy optimizations. After checking its optimizations I also find the code more readable and easier to understand.

The difference in processing time is amazing.
Without the optimizations the processing time was somewhere between 15 and 30 seconds.
With the optimizations the processing time is reduced to only 0.8 to 1.2 seconds!

These timing are based on two log lines were `buildforcastdata` is in between.

These are the results (filtered from the log) of the hourly forecast calculations WITHOUT optimizations:
```
2024-05-28 07:56:40.453 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - load_saved_data file exists.. file type is <class 'dict'>
2024-05-28 07:56:55.032 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Data for 2024-05-28 contains all 48 records

2024-05-28 08:24:05.175 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Solcast returned 337 records (should be 168)
2024-05-28 08:24:20.747 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Data for 2024-05-28 contains all 48 records

2024-05-28 09:24:07.332 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Solcast returned 337 records (should be 168)
2024-05-28 09:24:28.883 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Data for 2024-05-28 contains all 48 records

2024-05-28 10:24:05.391 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Solcast returned 337 records (should be 168)
2024-05-28 10:24:33.659 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Data for 2024-05-28 contains all 48 records

2024-05-28 11:24:06.089 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Solcast returned 337 records (should be 168)
2024-05-28 11:24:32.011 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Data for 2024-05-28 contains all 48 records

2024-05-28 12:24:05.192 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Solcast returned 337 records (should be 168)
2024-05-28 12:24:31.050 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Data for 2024-05-28 contains all 48 records

2024-05-28 13:24:06.632 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Solcast returned 337 records (should be 168)
2024-05-28 13:24:29.089 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Data for 2024-05-28 contains all 48 records

2024-05-28 14:24:05.227 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Solcast returned 337 records (should be 168)
2024-05-28 14:24:35.072 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Data for 2024-05-28 contains all 48 records

2024-05-28 15:24:06.461 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Solcast returned 337 records (should be 168)
2024-05-28 15:24:34.263 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Data for 2024-05-28 contains all 48 records

2024-05-28 16:24:06.784 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Solcast returned 337 records (should be 168)
2024-05-28 16:24:31.843 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Data for 2024-05-28 contains all 48 records
```

These are the results WITH the optimizations:
```
2024-05-27 21:24:43.704 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Solcast returned 337 records (should be 168)
2024-05-27 21:24:44.690 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Data for 2024-05-27 contains all 48 records

2024-05-28 02:24:05.461 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Solcast returned 337 records (should be 168)
2024-05-28 02:24:06.263 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Data for 2024-05-28 contains all 48 records

2024-05-28 03:24:06.136 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Solcast returned 337 records (should be 168)
2024-05-28 03:24:07.399 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Data for 2024-05-28 contains all 48 records

2024-05-28 04:24:06.431 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Solcast returned 337 records (should be 168)
2024-05-28 04:24:07.666 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Data for 2024-05-28 contains all 48 records

2024-05-28 05:24:06.115 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Solcast returned 337 records (should be 168)
2024-05-28 05:24:07.326 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Data for 2024-05-28 contains all 48 records

2024-05-28 06:24:04.996 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Solcast returned 337 records (should be 168)
2024-05-28 06:24:06.097 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Data for 2024-05-28 contains all 48 records

2024-05-28 07:24:05.541 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Solcast returned 337 records (should be 168)
2024-05-28 07:24:06.726 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Data for 2024-05-28 contains all 48 records
```


